### PR TITLE
Update gtl.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Clone and run ./gruyere.py
 
 I've added minor changes for Python 3 compatibility (the code is python2/3 compatible). You might need a `pip3 install future`
 
-Tested on Linux/Unix with Python 2.7, 3.6 and 3.7
+Tested on Linux/Unix with Python 2.7 to 3.9
 ## credits
 Base code is Copyright 2017 Google Inc. All Rights Reserved.
 

--- a/gtl.py
+++ b/gtl.py
@@ -23,7 +23,7 @@ import collections
 __author__ = 'Bruce Leban'
 
 # system modules
-import cgi
+import html
 import logging
 import operator
 import os
@@ -216,7 +216,7 @@ def _ExpandVariable(var, specials, params, name, default=''):
     value = not value
 
   if escaper_name == 'text':
-    value = cgi.escape(str(value))
+    value = html.escape(str(value))
   elif escaper_name == 'html':
     value = sanitize.SanitizeHtml(str(value))
   elif escaper_name == 'pprint':  # for debugging


### PR DESCRIPTION
cgi.escape() is deprecated in python 3.9
updated with import html and html.escape()